### PR TITLE
Change pythainlp dev to release

### DIFF
--- a/source/notebooks/text_generation.ipynb
+++ b/source/notebooks/text_generation.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "# #uncomment if you are running from google colab\n",
     "# !pip install sklearn_crfsuite\n",
-    "# !pip install https://github.com/PyThaiNLP/pythainlp/archive/dev.zip\n",
+    "# !pip install pythainlp\n",
     "# !pip install fastai\n",
     "# !pip install emoji"
    ]


### PR DESCRIPTION
According to https://github.com/PyThaiNLP/tutorials/pull/12#pullrequestreview-418215454

I've changed pythainlp dev to pythainlp release in pip install cell.